### PR TITLE
Fix Metamask auto reconnection

### DIFF
--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -77,6 +77,9 @@ export function useWeb3() {
         isConnecting: false,
         error: null,
       })
+      if (typeof window !== "undefined") {
+        localStorage.setItem("connected", "1")
+      }
       console.log("Connected:", { provider, signer, account, chainId })
     } catch (error: any) {
       setState((prev) => ({
@@ -98,7 +101,27 @@ export function useWeb3() {
       isConnecting: false,
       error: null,
     })
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("connected")
+    }
   }, [])
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.ethereum) {
+      const shouldReconnect = localStorage.getItem("connected") === "1"
+      if (shouldReconnect) {
+        // attempt to reconnect silently
+        window.ethereum
+          .request({ method: "eth_accounts" })
+          .then((accounts: string[]) => {
+            if (accounts.length > 0) {
+              connect()
+            }
+          })
+          .catch((err: any) => console.error("Auto connect error:", err))
+      }
+    }
+  }, [connect])
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.ethereum) {


### PR DESCRIPTION
## Summary
- automatically reconnect to MetaMask if previously connected
- persist connection state in localStorage

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd1e96d1c8327b5cd52f4cb3f969b