### PR TITLE
Fix Metamask auto reconnection

### DIFF
--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -14,6 +14,7 @@ interface Dataset {
   id: number
   ipfsHash: string
   price: string
+  priceWei: bigint
   seller: string
   active: boolean
 }

--- a/components/dataset-detail-modal.tsx
+++ b/components/dataset-detail-modal.tsx
@@ -15,6 +15,7 @@ interface Dataset {
   id: number
   ipfsHash: string
   price: string
+  priceWei: bigint
   seller: string
   active: boolean
 }
@@ -60,7 +61,7 @@ export function DatasetDetailModal({ dataset, open, onOpenChange }: DatasetDetai
 
     setPurchasing(true)
     try {
-      await purchaseDataset(dataset.id, dataset.price)
+      await purchaseDataset(dataset.id, dataset.priceWei)
       toast({
         title: "Purchase Successful",
         description: "Dataset purchased successfully!",

--- a/hooks/useMarketplace.ts
+++ b/hooks/useMarketplace.ts
@@ -19,6 +19,7 @@ interface Dataset {
   id: number
   ipfsHash: string
   price: string
+  priceWei: bigint
   seller: string
   active: boolean
 }
@@ -51,6 +52,7 @@ export function useMarketplace() {
           id: Number(dataset.id),
           ipfsHash: dataset.ipfsHash,
           price: ethers.formatEther(dataset.price),
+          priceWei: dataset.price,
           seller: dataset.seller,
           active: dataset.active,
         })
@@ -92,12 +94,12 @@ export function useMarketplace() {
   )
 
   const purchaseDataset = useCallback(
-    async (id: number, price: string) => {
+    async (id: number, price: ethers.BigNumberish) => {
       const contract = getContract()
       if (!contract || !signer) throw new Error("Wallet not connected")
 
       const tx = await contract.purchaseDataset(id, {
-        value: ethers.parseEther(price),
+        value: price,
       })
       await tx.wait()
 

--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -77,6 +77,9 @@ export function useWeb3() {
         isConnecting: false,
         error: null,
       })
+      if (typeof window !== "undefined") {
+        localStorage.setItem("connected", "1")
+      }
       console.log("Connected:", { provider, signer, account, chainId })
     } catch (error: any) {
       setState((prev) => ({
@@ -98,7 +101,27 @@ export function useWeb3() {
       isConnecting: false,
       error: null,
     })
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("connected")
+    }
   }, [])
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.ethereum) {
+      const shouldReconnect = localStorage.getItem("connected") === "1"
+      if (shouldReconnect) {
+        // attempt to reconnect silently
+        window.ethereum
+          .request({ method: "eth_accounts" })
+          .then((accounts: string[]) => {
+            if (accounts.length > 0) {
+              connect()
+            }
+          })
+          .catch((err: any) => console.error("Auto connect error:", err))
+      }
+    }
+  }, [connect])
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.ethereum) {


### PR DESCRIPTION
## Summary
- automatically reconnect to MetaMask if previously connected
- persist connection state in localStorage
- fix purchase overflow by submitting the price in wei

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd1e96d1c8327b5cd52f4cb3f969b