### PR TITLE
Fix incorrect ETH value on purchase

### DIFF
--- a/components/dataset-detail-modal.tsx
+++ b/components/dataset-detail-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { ethers } from "ethers"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -61,7 +62,8 @@ export function DatasetDetailModal({ dataset, open, onOpenChange }: DatasetDetai
 
     setPurchasing(true)
     try {
-      await purchaseDataset(dataset.id, dataset.priceWei)
+      const price = ethers.parseEther(dataset.price)
+      await purchaseDataset(dataset.id, price)
       toast({
         title: "Purchase Successful",
         description: "Dataset purchased successfully!",


### PR DESCRIPTION
## Summary
- import `ethers` in DatasetDetailModal
- parse the dataset's price in ETH before sending to contract

## Testing
- `pnpm install --ignore-scripts` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_685beb39e1c48327ae3194bc79927d30