### PR TITLE
Improve dataset visibility

### DIFF
--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -21,11 +21,11 @@ interface Dataset {
 
 export default function MarketPage() {
   const { isConnected } = useWeb3Context()
-  const { datasets, loading } = useMarketplace()
+  const { allDatasets, loading } = useMarketplace()
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
 
-  const filteredDatasets = datasets.filter(
+  const filteredDatasets = allDatasets.filter(
     (dataset) =>
       dataset.ipfsHash.toLowerCase().includes(searchTerm.toLowerCase()) ||
       dataset.seller.toLowerCase().includes(searchTerm.toLowerCase()),
@@ -82,7 +82,11 @@ export default function MarketPage() {
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
                   <span>Dataset #{dataset.id}</span>
-                  <Badge variant="secondary">Active</Badge>
+                  {dataset.buyer === "0x0000000000000000000000000000000000000000" ? (
+                    <Badge variant="secondary">Active</Badge>
+                  ) : (
+                    <Badge variant="outline">Sold</Badge>
+                  )}
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">

--- a/components/dataset-detail-modal.tsx
+++ b/components/dataset-detail-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { ethers } from "ethers"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -81,6 +82,7 @@ export function DatasetDetailModal({ dataset, open, onOpenChange }: DatasetDetai
   if (!dataset) return null
 
   const isOwner = account?.toLowerCase() === dataset.seller.toLowerCase()
+  const isSold = dataset.buyer !== ethers.ZeroAddress
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -164,7 +166,7 @@ export function DatasetDetailModal({ dataset, open, onOpenChange }: DatasetDetai
                 </p>
               </div>
 
-              {!isOwner && account && (
+              {!isOwner && !isSold && account && (
                 <Button onClick={handlePurchase} disabled={purchasing} className="w-full">
                   {purchasing ? (
                     <>
@@ -175,6 +177,10 @@ export function DatasetDetailModal({ dataset, open, onOpenChange }: DatasetDetai
                     `Purchase for ${dataset.price} ETH`
                   )}
                 </Button>
+              )}
+
+              {isSold && !isOwner && (
+                <div className="text-center text-muted-foreground">Dataset already sold</div>
               )}
 
               {isOwner && <div className="text-center text-muted-foreground">You own this dataset</div>}

--- a/hooks/useMarketplace.ts
+++ b/hooks/useMarketplace.ts
@@ -27,6 +27,7 @@ interface Dataset {
 export function useMarketplace() {
   const { provider, signer, account } = useWeb3()
   const [datasets, setDatasets] = useState<Dataset[]>([])
+  const [allDatasets, setAllDatasets] = useState<Dataset[]>([])
   const [loading, setLoading] = useState(false)
   const [pendingWithdrawal, setPendingWithdrawal] = useState("0")
 
@@ -59,6 +60,7 @@ export function useMarketplace() {
         })
       }
 
+      setAllDatasets(datasetsData)
       setDatasets(datasetsData.filter((d) => d.buyer === ethers.ZeroAddress))
     } catch (error) {
       console.error("Error loading datasets:", error)
@@ -154,6 +156,7 @@ export function useMarketplace() {
 
   return {
     datasets,
+    allDatasets,
     loading,
     pendingWithdrawal,
     listDataset,


### PR DESCRIPTION
## Summary
- extend marketplace hook to store all datasets
- show active/sold status in marketplace list
- disable purchase when dataset already sold

## Testing
- `pnpm install` *(fails: network access blocked)*
- `pnpm build` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe692124832794833b3fa9c0d229