### PR TITLE
Handle auto-connect failure in Web3 hook

### DIFF
--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -111,14 +111,18 @@ export function useWeb3() {
       const shouldReconnect = localStorage.getItem("connected") === "1"
       if (shouldReconnect) {
         // attempt to reconnect silently
-        window.ethereum
-          .request({ method: "eth_accounts" })
-          .then((accounts: string[]) => {
+        ;(async () => {
+          try {
+            const accounts: string[] = await window.ethereum.request({
+              method: "eth_accounts",
+            })
             if (accounts.length > 0) {
               connect()
             }
-          })
-          .catch((err: any) => console.error("Auto connect error:", err))
+          } catch (err: any) {
+            console.error("Auto connect error:", err)
+          }
+        })()
       }
     }
   }, [connect])


### PR DESCRIPTION
## Summary
- handle errors during automatic wallet reconnect to avoid unhandled runtime errors

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c151770c8832786f455935d77bcc1